### PR TITLE
Fix: Correct initial globe sizing on mobile

### DIFF
--- a/src/InteractiveGlobeView.jsx
+++ b/src/InteractiveGlobeView.jsx
@@ -50,10 +50,14 @@ const InteractiveGlobeView = ({
             }
         };
         const debouncedUpdateDimensions = debounce(updateDimensions, 200);
-        updateDimensions();
+        updateDimensions(); // Initial immediate call
+        const timerId = setTimeout(updateDimensions, 50); // Delayed call
+
         const resizeObserver = new ResizeObserver(debouncedUpdateDimensions);
         resizeObserver.observe(currentContainerRef);
+
         return () => {
+            if (timerId) clearTimeout(timerId); // Clear the timeout
             if (currentContainerRef) resizeObserver.unobserve(currentContainerRef);
             if (debouncedUpdateDimensions.timeout) clearTimeout(debouncedUpdateDimensions.timeout);
         };


### PR DESCRIPTION
The globe component was initially rendering too large on mobile devices, obscuring the bottom navigation menu. This was due to the globe's dimensions being calculated before the browser had fully stabilized the layout, particularly concerning the fixed-position bottom navigation.

This commit addresses the issue by modifying the `InteractiveGlobeView.jsx` component. An additional call to `updateDimensions` is now made within a 50ms `setTimeout` during the initial `useEffect` hook. This brief delay allows the browser layout to settle, ensuring that the globe dimensions are calculated correctly from the start. The existing ResizeObserver continues to handle subsequent resize events.