### PR TITLE
Fix: Integrate cluster modal with router for proper back button behav…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import GlobalLastMajorQuakeTimer                                    from "./Glob
 import BottomNav                                                    from "./BottomNav.jsx"; // Direct import
 import ClusterSummaryItem from './ClusterSummaryItem'; // Add this line
 import ClusterDetailModal from './ClusterDetailModal';
+import ClusterDetailModalWrapper from './ClusterDetailModalWrapper.jsx';
 import { calculateDistance, getMagnitudeColor } from './utils';
 
 // --- Configuration & Helpers ---
@@ -719,7 +720,6 @@ function App() {
     // const [activeSidebarView, setActiveSidebarView] = useState('overview_panel'); // Replaced by useSearchParams
     const [searchParams, setSearchParams] = useSearchParams();
     const [activeClusters, setActiveClusters] = useState([]);
-    const [detailedClusterToShow, setDetailedClusterToShow] = useState(null); // <-- Add this line
     const activeSidebarView = searchParams.get('sidebarActiveView') || 'overview_panel';
 
     const setActiveSidebarView = (view) => {
@@ -1351,8 +1351,8 @@ function App() {
     }, [navigate]);
 
     const handleClusterSummaryClick = useCallback((clusterData) => {
-        setDetailedClusterToShow(clusterData);
-    }, []); // No dependencies needed if setDetailedClusterToShow is stable (which it is)
+        navigate(`/cluster/${clusterData.id}`);
+    }, [navigate]); // Added navigate to dependencies
 
     const initialDataLoaded = useMemo(() => earthquakesLastHour || earthquakesLast24Hours || earthquakesLast72Hours || earthquakesLast7Days, [earthquakesLastHour, earthquakesLast24Hours, earthquakesLast72Hours, earthquakesLast7Days]);
 
@@ -1717,6 +1717,7 @@ function App() {
                                 (allEarthquakes && allEarthquakes.length > 0 && earthquakesLast30Days && earthquakesLast30Days.length > 0) ? earthquakesLast30Days : earthquakesLast7Days
                             } />}
                         />
+                        <Route path="/cluster/:clusterId" element={<ClusterDetailModalWrapper overviewClusters={overviewClusters} formatDate={formatDate} getMagnitudeColorStyle={getMagnitudeColorStyle} onIndividualQuakeSelect={handleQuakeClick} />} />
                     </Routes>
                 </main>
 
@@ -1885,16 +1886,6 @@ function App() {
 
             <BottomNav />
 
-            {/* Conditionally render ClusterDetailModal */}
-            {detailedClusterToShow && (
-                <ClusterDetailModal
-                    cluster={detailedClusterToShow}
-                    onClose={() => setDetailedClusterToShow(null)}
-                    formatDate={formatDate} // Pass the utility function from App.jsx
-                    getMagnitudeColorStyle={getMagnitudeColorStyle} // Pass the utility function from App.jsx
-                    onIndividualQuakeSelect={handleQuakeClick} // <-- Add this line
-                />
-            )}
             {/* Removed direct rendering of EarthquakeDetailView, now handled by routing */}
         </div>
     );

--- a/src/ClusterDetailModalWrapper.jsx
+++ b/src/ClusterDetailModalWrapper.jsx
@@ -1,0 +1,54 @@
+// src/ClusterDetailModalWrapper.jsx
+import React from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import ClusterDetailModal from './ClusterDetailModal';
+
+/**
+ * Wrapper component for ClusterDetailModal to integrate with React Router.
+ * It fetches cluster details based on URL parameters and handles navigation.
+ */
+function ClusterDetailModalWrapper({ overviewClusters, formatDate, getMagnitudeColorStyle, onIndividualQuakeSelect }) {
+    const { clusterId } = useParams();
+    const navigate = useNavigate();
+
+    // Find the cluster data from overviewClusters using clusterId
+    // Note: overviewClusters is expected to be an array of cluster objects,
+    // each having an 'id' property.
+    const cluster = overviewClusters?.find(c => c.id === clusterId);
+
+    const handleClose = () => {
+        navigate(-1); // Go back to the previous page
+    };
+
+    if (!cluster) {
+        // Handle case where cluster is not found, e.g., show a message or redirect
+        // For now, returning null or a simple message.
+        // Consider navigating back or to a not-found page in a real app.
+        return (
+            <div className="fixed inset-0 bg-slate-900 bg-opacity-75 flex items-center justify-center z-50 p-4">
+                <div className="bg-slate-800 p-6 rounded-lg shadow-2xl text-slate-200 border border-slate-700">
+                    <h2 className="text-xl font-semibold text-amber-400 mb-3">Cluster Not Found</h2>
+                    <p className="text-sm mb-4">The cluster details you are looking for could not be found. It might have expired or the link may be incorrect.</p>
+                    <button
+                        onClick={handleClose}
+                        className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-md transition-colors"
+                    >
+                        Go Back
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <ClusterDetailModal
+            cluster={cluster}
+            onClose={handleClose}
+            formatDate={formatDate}
+            getMagnitudeColorStyle={getMagnitudeColorStyle}
+            onIndividualQuakeSelect={onIndividualQuakeSelect} // Pass this down
+        />
+    );
+}
+
+export default ClusterDetailModalWrapper;


### PR DESCRIPTION
…ior.

The active clusters detail modal was previously managed by local component state in App.jsx. This caused issues with the browser's back button, as it wouldn't close the modal but rather navigate the underlying page.

This change refactors the cluster detail modal to be route-based:
1.  A new route `/cluster/:clusterId` is introduced in `App.jsx`.
2.  A `ClusterDetailModalWrapper.jsx` component is created to handle this route, retrieve cluster data based on the `clusterId` URL parameter, and manage navigation for closing the modal (`navigate(-1)`).
3.  Clicking a cluster summary item now navigates to this new route.
4.  The old state-based management (`detailedClusterToShow`) for the cluster modal in `App.jsx` has been removed.
5.  Clicking an individual earthquake within the cluster modal now correctly navigates to that earthquake's detail page using the existing routing mechanism.

This ensures that the cluster detail modal correctly interacts with the browser's history, and the back button works as you would expect.