### PR TITLE
feat: Auto-load monthly data on earthquake detail view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1737,9 +1737,7 @@ function App() {
                         } />
                         <Route
                             path="/quake/:detailUrlParam"
-                            element={<EarthquakeDetailModal broaderEarthquakeData={
-                                (allEarthquakes && allEarthquakes.length > 0 && earthquakesLast30Days && earthquakesLast30Days.length > 0) ? earthquakesLast30Days : earthquakesLast7Days
-                            } />}
+                            element={<EarthquakeDetailModal broaderEarthquakeData={ (allEarthquakes && allEarthquakes.length > 0 && earthquakesLast30Days && earthquakesLast30Days.length > 0) ? earthquakesLast30Days : earthquakesLast7Days } handleLoadMonthlyData={handleLoadMonthlyData} hasAttemptedMonthlyLoad={hasAttemptedMonthlyLoad} isLoadingMonthly={isLoadingMonthly} />}
                         />
                         <Route path="/cluster/:clusterId" element={<ClusterDetailModalWrapper overviewClusters={overviewClusters} formatDate={formatDate} getMagnitudeColorStyle={getMagnitudeColorStyle} onIndividualQuakeSelect={handleQuakeClick} />} />
                     </Routes>
@@ -1921,7 +1919,7 @@ function App() {
  * manages the modal's open/close state based on navigation.
  * @returns {JSX.Element} The rendered EarthquakeDetailView component configured as a modal.
  */
-const EarthquakeDetailModal = ({ broaderEarthquakeData, dataSourceTimespanDays }) => { // Add dataSourceTimespanDays
+const EarthquakeDetailModal = ({ broaderEarthquakeData, dataSourceTimespanDays, handleLoadMonthlyData, hasAttemptedMonthlyLoad, isLoadingMonthly }) => { // Add dataSourceTimespanDays
     const { detailUrlParam } = useParams();
     const navigate = useNavigate();
     const detailUrl = decodeURIComponent(detailUrlParam);
@@ -1937,6 +1935,9 @@ const EarthquakeDetailModal = ({ broaderEarthquakeData, dataSourceTimespanDays }
                 onClose={handleClose}
                 broaderEarthquakeData={broaderEarthquakeData}
                 dataSourceTimespanDays={dataSourceTimespanDays} // Pass it down
+                handleLoadMonthlyData={handleLoadMonthlyData}
+                hasAttemptedMonthlyLoad={hasAttemptedMonthlyLoad}
+                isLoadingMonthly={isLoadingMonthly}
             />;
 };
 

--- a/src/EarthquakeDetailView.jsx
+++ b/src/EarthquakeDetailView.jsx
@@ -223,11 +223,19 @@ const SkeletonBlock = ({ height = 'h-24', className = '' }) => <div className={`
  * @param {number} props.dataSourceTimespanDays - The timespan (e.g., 7 or 30 days) of the `broaderEarthquakeData` source, used by RegionalSeismicityChart for context.
  * @returns {JSX.Element} The rendered EarthquakeDetailView component.
  */
-function EarthquakeDetailView({ detailUrl, onClose, onDataLoadedForSeo, broaderEarthquakeData, dataSourceTimespanDays }) { // Add dataSourceTimespanDays
+function EarthquakeDetailView({ detailUrl, onClose, onDataLoadedForSeo, broaderEarthquakeData, dataSourceTimespanDays, handleLoadMonthlyData, hasAttemptedMonthlyLoad, isLoadingMonthly }) { // Add dataSourceTimespanDays
     const [detailData, setDetailData] = useState(null);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState(null);
     const [selectedFaultPlaneKey, setSelectedFaultPlaneKey] = useState('np1');
+
+    useEffect(() => {
+        // Check if monthly data has not been attempted to load yet and is not currently loading
+        if (hasAttemptedMonthlyLoad === false && isLoadingMonthly === false && typeof handleLoadMonthlyData === 'function') {
+            console.log('EarthquakeDetailView: Triggering monthly data load.');
+            handleLoadMonthlyData();
+        }
+    }, [detailUrl, hasAttemptedMonthlyLoad, isLoadingMonthly, handleLoadMonthlyData]); // Dependencies for the effect
 
     useEffect(() => {
         if (!detailUrl) return;


### PR DESCRIPTION
Implements automatic loading of the monthly earthquake data feed (all_month.geojson) when you navigate to an individual earthquake's detail page, provided this data hasn't been loaded already.

This change enhances the experience by ensuring that components on the detail page, such as the regional seismicity chart, have access to a richer dataset (14-day or 30-day context) without requiring a prior manual data load.

The following modifications were made:
- `App.jsx`:
    - Passed `handleLoadMonthlyData`, `hasAttemptedMonthlyLoad`, and `isLoadingMonthly` props to `EarthquakeDetailModal`.
    - `EarthquakeDetailModal` was updated to relay these props to `EarthquakeDetailView`.
- `EarthquakeDetailView.jsx`:
    - Added a `useEffect` hook to call `handleLoadMonthlyData` on component mount if monthly data is not yet loaded or loading.
    - Updated props destructuring to accept the new data loading functions and state variables.

This addresses the requirement to provide more contextual data on the detail page while still maintaining a fast initial load for the overall application by fetching the larger monthly dataset on-demand.