### PR TITLE
Fix: Resolve mobile navbar spacing issue

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,8 @@
 #root {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
   text-align: center;
 }
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -731,7 +731,7 @@ function App() {
 
     return (
         <div className="flex flex-col h-[100svh] font-sans bg-slate-900 text-slate-100 antialiased">
-            <header className="bg-slate-800 text-white p-2 shadow-lg z-40 border-b border-slate-700">
+            <header className="bg-slate-800 text-white pt-4 pb-2 px-2 shadow-lg z-40 border-b border-slate-700">
                 <div className="mx-auto flex flex-col sm:flex-row justify-between items-center px-3">
                     <h1 className="text-lg md:text-xl font-bold text-indigo-400">Global Seismic Activity Monitor</h1>
                     <p className="text-xs sm:text-sm text-slate-400 mt-0.5 sm:mt-0">{headerTimeDisplay}</p>


### PR DESCRIPTION
This commit addresses a layout problem on mobile devices where unexpected spacing would appear, particularly when the browser's top navigation bar would hide or display. This was related to the interaction between the fixed bottom navigation and global padding settings.

Changes:
- Modified `#root` styles in `src/App.css`: Removed top and bottom padding to prevent interference with viewport height calculations and fixed positioning of navigation elements. Horizontal padding was retained.
- Adjusted header padding in `src/pages/HomePage.jsx`: Increased the top padding of the main application header to compensate for the removal of `#root`'s top padding, ensuring adequate spacing.

These changes ensure that the main content area and bottom navigation padding are more directly and accurately sized relative to the viewport, mitigating the inconsistent spacing.