### PR TITLE
feat: Adjust earthquake marker dimming to daily intervals

### DIFF
--- a/src/components/EarthquakeMap.jsx
+++ b/src/components/EarthquakeMap.jsx
@@ -56,12 +56,31 @@ const createEpicenterIcon = (magnitude) => {
 /**
  * Creates a custom Leaflet DivIcon for a nearby earthquake.
  * @param {number} magnitude - The earthquake magnitude to determine the icon color.
+ * @param {number} time - The time of the earthquake (timestamp).
  * @returns {L.DivIcon} A Leaflet DivIcon instance.
  */
-const createNearbyQuakeIcon = (magnitude) => {
+const createNearbyQuakeIcon = (magnitude, time) => {
   const fillColor = getMagnitudeColor(magnitude);
+  const currentTime = Date.now();
+  const ageInDays = (currentTime - time) / (1000 * 60 * 60 * 24);
+
+  let opacity;
+  if (ageInDays < 1) {
+    opacity = 1.0;
+  } else if (ageInDays < 7) {
+    opacity = 0.8;
+  } else if (ageInDays < 14) {
+    opacity = 0.6;
+  } else {
+    opacity = 0.4;
+  }
+
+  // Convert opacity to 2-digit hex string
+  const alphaHex = Math.round(opacity * 255).toString(16).padStart(2, '0');
+  const finalColor = fillColor + alphaHex;
+
   return new L.DivIcon({
-    html: `<svg width="18" height="18" viewBox="0 0 18 18"><circle cx="9" cy="9" r="5" fill="${fillColor}" /></svg>`,
+    html: `<svg width="18" height="18" viewBox="0 0 18 18"><circle cx="9" cy="9" r="5" fill="${finalColor}" /></svg>`,
     className: 'custom-nearby-quake-icon',
     iconSize: [18, 18],
     iconAnchor: [9, 9],
@@ -152,7 +171,7 @@ const EarthquakeMap = ({ latitude, longitude, magnitude, title, shakeMapUrl, nea
         <Marker
           key={index}
           position={[quake.geometry.coordinates[1], quake.geometry.coordinates[0]]}
-          icon={createNearbyQuakeIcon(quake.properties.mag)}
+          icon={createNearbyQuakeIcon(quake.properties.mag, quake.properties.time)}
         >
           <Popup>
             Magnitude: {quake.properties.mag}


### PR DESCRIPTION
This commit updates the earthquake marker dimming feature to use daily intervals instead of hourly ones, based on your feedback. This change is intended to better suit the display of up to 30 days of earthquake data on the regional map.

The following changes were made:

- The `createNearbyQuakeIcon` function in `src/components/EarthquakeMap.jsx` was modified to calculate earthquake age in days.
- Opacity levels were adjusted for daily intervals:
    - Less than 1 day old: opacity 1.0
    - 1 to 7 days old: opacity 0.8
    - 7 to 14 days old: opacity 0.6
    - Older than 14 days: opacity 0.4
- I confirmed that the application builds and runs with these changes, and the logic for daily dimming is correctly implemented.