### PR TITLE
Refactor: Centralize USGS API calls with usgsApiService

### DIFF
--- a/src/contexts/EarthquakeDataContext.jsx
+++ b/src/contexts/EarthquakeDataContext.jsx
@@ -1,8 +1,7 @@
 // src/contexts/EarthquakeDataContext.jsx
-import React, { createContext, useContext, useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import React, { createContext, useContext, useMemo } from 'react'; // Removed useState, useEffect, useCallback, useRef as they are not directly used here
 import useEarthquakeData from '../hooks/useEarthquakeData';
 import useMonthlyEarthquakeData from '../hooks/useMonthlyEarthquakeData';
-import { fetchDataCb } from '../utils/fetchUtils';
 
 const EarthquakeDataContext = createContext(null);
 
@@ -32,7 +31,7 @@ export const EarthquakeDataProvider = ({ children }) => {
         setTimeBetweenPreviousMajorQuakes,
         currentLoadingMessage,
         isInitialAppLoad
-    } = useEarthquakeData(fetchDataCb);
+    } = useEarthquakeData();
 
     const {
         isLoadingMonthly,
@@ -45,7 +44,6 @@ export const EarthquakeDataProvider = ({ children }) => {
         prev14DayData,
         loadMonthlyData
     } = useMonthlyEarthquakeData(
-        fetchDataCb,
         lastMajorQuake,
         setLastMajorQuake,
         setPreviousMajorQuake,

--- a/src/services/usgsApiService.js
+++ b/src/services/usgsApiService.js
@@ -1,0 +1,20 @@
+// src/services/usgsApiService.js
+
+export const fetchUsgsData = async (apiUrl) => {
+  try {
+    const response = await fetch(apiUrl);
+    if (!response.ok) {
+      throw { message: `HTTP error! status: ${response.status}`, status: response.status };
+    }
+    const data = await response.json();
+    return data; // Or { data: data } if you prefer to wrap successful responses
+  } catch (error) {
+    console.error("USGS API Service Error:", error);
+    return { 
+      error: { 
+        message: error.message || 'Failed to fetch data. Network error or invalid JSON.', 
+        status: error.status || null 
+      } 
+    };
+  }
+};


### PR DESCRIPTION
I've created a dedicated service module `src/services/usgsApiService.js` to encapsulate all logic for fetching data from USGS API endpoints.

I then refactored your `useEarthquakeData` and `useMonthlyEarthquakeData` hooks to utilize this new service, removing the direct fetch operations and the `fetchDataCb` pattern.

I also updated `EarthquakeDataContext` to reflect these changes in hook invocation.

Test files for the affected hooks (`useEarthquakeData.test.js`, `useMonthlyEarthquakeData.test.js`) were updated to mock the new service and ensure continued test coverage. All relevant tests are passing.

The application builds successfully with these changes.