### PR TITLE
Fix: Enable click outside to close for modals

### DIFF
--- a/src/components/ClusterDetailModal.jsx
+++ b/src/components/ClusterDetailModal.jsx
@@ -111,7 +111,7 @@ function ClusterDetailModal({ cluster, onClose, formatDate, getMagnitudeColorSty
     return (
         <div
             className="fixed inset-0 bg-slate-900 bg-opacity-75 flex items-center justify-center z-40 p-4 transition-opacity duration-300 ease-in-out"
-            // onClick={onClose} // Removed backdrop click to close, rely on Esc key and close button
+            onClick={onClose} // Removed backdrop click to close, rely on Esc key and close button
             role="dialog"
             aria-modal="true"
             aria-labelledby="cluster-detail-title"


### PR DESCRIPTION
I've implemented the ability for you to close modals by clicking outside of their content area.

- I modified `ClusterDetailModal.jsx` to enable `onClick={onClose}` on the backdrop div. This was previously commented out.
- I ensured that clicks within the modal content still do not close the modal by preserving `onClick={e => e.stopPropagation()}` on the content div.
- I verified that `EarthquakeDetailView.jsx` already had this functionality correctly implemented.
- I confirmed that automated tests passed, and the application build was successful.