### PR TITLE
Fix: Ensure correct globe sizing on mobile and adjust modal z-index.

### DIFF
--- a/src/components/ClusterDetailModal.jsx
+++ b/src/components/ClusterDetailModal.jsx
@@ -110,7 +110,7 @@ function ClusterDetailModal({ cluster, onClose, formatDate, getMagnitudeColorSty
 
     return (
         <div
-            className="fixed inset-0 bg-slate-900 bg-opacity-75 flex items-center justify-center z-40 p-4 transition-opacity duration-300 ease-in-out"
+            className="fixed inset-0 bg-slate-900 bg-opacity-75 flex items-center justify-center z-[51] p-4 transition-opacity duration-300 ease-in-out"
             onClick={onClose} // Removed backdrop click to close, rely on Esc key and close button
             role="dialog"
             aria-modal="true"

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -82,7 +82,7 @@ const GlobeLayout = (props) => {
   } = props;
 
   return (
-    <div className="lg:block h-full w-full"> {/* Base container for the globe and its fixed UI elements */}
+    <div className="block h-full w-full"> {/* Base container for the globe and its fixed UI elements */}
       <InteractiveGlobeView
         defaultFocusLat={20}
         defaultFocusLng={globeFocusLng}


### PR DESCRIPTION
- Modified GlobeLayout in HomePage.jsx to ensure its container div uses `block h-full w-full` on all screen sizes. This fixes an issue where the globe could be incorrectly sized before the first interaction on mobile due to its container not having a defined height.
- Adjusted the z-index of ClusterDetailModal.jsx from z-40 to z-[51] to ensure it and its backdrop render above the BottomNav component (z-50).
- Verified that EarthquakeDetailModalComponent and the updated ClusterDetailModal respect header and footer navigation on mobile, with appropriate max-height and overflow settings.
- Confirmed global padding and other layout elements are consistent and that changes did not introduce build errors or break existing tests.