### PR TITLE
Fix: Ensure ClusterMiniMap renders correctly within modal

### DIFF
--- a/src/components/ClusterDetailModal.jsx
+++ b/src/components/ClusterDetailModal.jsx
@@ -149,7 +149,7 @@ function ClusterDetailModal({ cluster, onClose, formatDate, getMagnitudeColorSty
 
                 {/* Cluster Mini Map */}
                 <div className="my-4"> {/* Added margin for spacing */}
-                    <ClusterMiniMap cluster={cluster} getMagnitudeColor={getMagnitudeColor} />
+                    <ClusterMiniMap cluster={cluster} getMagnitudeColor={getMagnitudeColor} containerRef={modalContentRef} />
                 </div>
 
                 {/* Individual Earthquakes List */}


### PR DESCRIPTION
The ClusterMiniMap component in the ClusterDetailModal could previously render before the modal had a determined size. This could lead to the map initializing with incorrect dimensions, causing visual glitches or errors.

This commit addresses the issue by:
1. Introducing a `ResizeObserver` in `ClusterMiniMap` to monitor the size of the modal's content area.
2. Passing the modal's content `div` ref (`modalContentRef`) from `ClusterDetailModal` to `ClusterMiniMap` as `containerRef`.
3. Delaying the rendering of the `MapContainer` in `ClusterMiniMap` until the `containerRef` reports a valid width (greater than 0). A "Loading map..." message is displayed during this time.
4. Ensuring `map.invalidateSize()` is called when the container size changes, allowing Leaflet to correctly recalculate map dimensions. This is handled by the `ResizeObserver` callback.
5. Adding `containerWidth` to the dependency array of the `useEffect` hook responsible for `map.fitBounds()`. This ensures that `fitBounds` is called only after the map has been initialized with the correct dimensions and whenever the container size changes.

These changes ensure that the map waits for the modal to be sized before rendering and that it can adapt to any subsequent size changes of the modal.