### PR TITLE
Fix: Stabilize mobile layout against browser UI shifts and correct mo…

### DIFF
--- a/src/components/ClusterDetailModal.jsx
+++ b/src/components/ClusterDetailModal.jsx
@@ -119,7 +119,7 @@ function ClusterDetailModal({ cluster, onClose, formatDate, getMagnitudeColorSty
             <div
                 ref={modalContentRef}
                 tabIndex="-1" // Make modal container focusable for trap if no inner elements are
-                className="bg-slate-800 p-4 sm:p-6 rounded-lg shadow-2xl w-full max-w-2xl max-h-[90vh] flex flex-col border border-slate-700 overflow-y-auto scrollbar-thin scrollbar-thumb-slate-600 scrollbar-track-slate-700"
+                className="bg-slate-800 p-4 sm:p-6 rounded-lg shadow-2xl w-full max-w-2xl max-h-[90svh] flex flex-col border border-slate-700 overflow-y-auto scrollbar-thin scrollbar-thumb-slate-600 scrollbar-track-slate-700"
                 onClick={e => e.stopPropagation()} // Prevent backdrop click from triggering inside modal
             >
                 {/* Header */}

--- a/src/components/EarthquakeDetailView.jsx
+++ b/src/components/EarthquakeDetailView.jsx
@@ -290,7 +290,7 @@ function EarthquakeDetailView({ detailUrl, onClose, onDataLoadedForSeo, broaderE
 
     return (
         <div
-            className="fixed inset-0 bg-black bg-opacity-70 flex justify-center items-start z-50 p-2 sm:p-4 pt-10 md:pt-16 overflow-y-auto"
+            className="fixed inset-0 bg-black bg-opacity-70 flex justify-center items-start z-[55] p-2 sm:p-4 pt-10 md:pt-16"
             onClick={onClose}
             role="dialog"
             aria-modal="true"
@@ -299,7 +299,7 @@ function EarthquakeDetailView({ detailUrl, onClose, onDataLoadedForSeo, broaderE
             <ErrorBoundary> {/* ErrorBoundary goes here, around the main content box */}
                 <div
                     ref={modalContentRef}
-                    className="bg-gray-100 rounded-lg shadow-xl max-w-3xl w-full mb-8 text-slate-800"
+                    className="bg-gray-100 rounded-lg shadow-xl max-w-3xl w-full mb-8 text-slate-800 overflow-y-auto max-h-[calc(100svh-5rem)]"
                 onClick={(e) => e.stopPropagation()}
                 tabIndex="-1" // Make the modal container focusable for the trap if no inner elements are
             >


### PR DESCRIPTION
…dal layering.

- Adjusted EarthquakeDetailView modal z-index from z-50 to z-[55] to ensure it reliably renders above the BottomNav (z-50).
- Standardized modal max heights to use `svh` units to prevent them from resizing when mobile browser UI (e.g., address bar) appears/disappears:
    - Changed ClusterDetailModal panel from `max-h-[90vh]` to `max-h-[90svh]`.
    - Modified EarthquakeDetailView panel to use `max-h-[calc(100svh-5rem)]` and manage its own `overflow-y-auto`. Removed `overflow-y-auto` from its outer fixed wrapper.
- These changes enhance layout stability on mobile devices, addressing issues where the main layout or modals could shift or be improperly layered due to dynamic viewport height changes.
- Confirmed main application layout uses `h-[100svh]` which is the correct strategy for base layout stability.