### PR TITLE
Fix: Align cluster mini-map height with detail page regional map

### DIFF
--- a/src/components/ClusterMiniMap.jsx
+++ b/src/components/ClusterMiniMap.jsx
@@ -132,7 +132,7 @@ const ClusterMiniMap = ({ cluster }) => {
 
   // Render the EarthquakeMap with the prepared props, wrapped in a div to maintain fixed height.
   return (
-    <div style={{ height: '200px', width: '100%' }}>
+    <div style={{ width: '100%' }} className="h-[300px] md:h-[400px] lg:h-[450px]">
       <EarthquakeMap {...mapProps} />
     </div>
   );


### PR DESCRIPTION
Updated the cluster mini-map component to use responsive Tailwind CSS height classes (`h-[300px] md:h-[400px] lg:h-[450px]`).

This change removes the previous fixed height of 200px and makes the cluster mini-map's height behavior identical to the regional map on the earthquake detail page, ensuring visual consistency across different screen sizes.