### PR TITLE
Refactor: Reduce header size on mobile devices

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -781,10 +781,10 @@ function App() {
 
     return (
         <div className="flex flex-col h-[100svh] font-sans bg-slate-900 text-slate-100 antialiased">
-            <header className="bg-slate-800 text-white pt-4 pb-2 px-2 shadow-lg z-40 border-b border-slate-700">
+            <header className="bg-slate-800 text-white pt-2 sm:pt-4 pb-1 sm:pb-2 px-2 shadow-lg z-40 border-b border-slate-700">
                 <div className="mx-auto flex flex-col sm:flex-row justify-between items-center px-3">
-                    <h1 className="text-lg md:text-xl font-bold text-indigo-400">Global Seismic Activity Monitor</h1>
-                    <p className="text-xs sm:text-sm text-slate-400 mt-0.5 sm:mt-0">{headerTimeDisplay}</p>
+                    <h1 className="text-base sm:text-lg md:text-xl font-bold text-indigo-400">Global Seismic Activity Monitor</h1>
+                    <p className="text-[0.7rem] sm:text-xs sm:text-sm text-slate-400 mt-0.5 sm:mt-0">{headerTimeDisplay}</p>
                 </div>
             </header>
 


### PR DESCRIPTION
This commit adjusts the Tailwind CSS classes for the main header in `src/pages/HomePage.jsx` to make it smaller on mobile screens.

- I reduced top/bottom padding of the header element on screens smaller than the 'sm' breakpoint.
- I reduced font size of the main title (h1) on screens smaller than the 'sm' breakpoint.
- I reduced font size of the subtitle (p) on screens smaller than the 'sm' breakpoint.

These changes improve the user experience on smaller devices by freeing up vertical screen space.