### PR TITLE
Fix: Prevent initial zoom-out on regional map in detail view

### DIFF
--- a/src/components/earthquakeDetail/EarthquakeRegionalMapPanel.jsx
+++ b/src/components/earthquakeDetail/EarthquakeRegionalMapPanel.jsx
@@ -69,7 +69,7 @@ function EarthquakeRegionalMapPanel({
         console.log("[EarthquakeRegionalMapPanel] Skipping highlightProps due to invalid/missing properties or magnitude.");
     }
 
-    const fitMap = regionalQuakes && regionalQuakes.length > 0;
+    const fitMap = false;
     const finalMapProps = {
         mapCenterLatitude: mapCenterLat,
         mapCenterLongitude: mapCenterLng,
@@ -77,7 +77,7 @@ function EarthquakeRegionalMapPanel({
         shakeMapUrl: shakemapIntensityImageUrl,
         nearbyQuakes: regionalQuakes,
         mainQuakeDetailUrl: detailUrl,
-        fitMapToBounds: fitMap,
+        fitMapToBounds: false,
         // defaultZoom is handled by EarthquakeMap's defaults
     };
 


### PR DESCRIPTION
The regional map on the earthquake detail view was initially zooming out to encompass all regional quakes. This change modifies the `EarthquakeRegionalMapPanel.jsx` component to set the `fitMapToBounds` prop to `false` unconditionally for its `EarthquakeMap` instance.

This ensures the regional map maintains its initial zoom level, and other nearby quakes become visible only if you manually zoom out.

The cluster view's map functionality, which correctly uses `fitMapToBounds=true`, remains unchanged.