### PR TITLE
feat: Migrate Kv store usage to D1

### DIFF
--- a/functions/[[catchall]].js
+++ b/functions/[[catchall]].js
@@ -14,69 +14,6 @@ const jsonErrorResponse = (message, status, sourceName, upstreamStatus = undefin
   });
 };
 
-async function handleClusterDefinitionRequest(context, url) {
-  const sourceName = "cluster-definition-handler";
-  const { request, env } = context;
-  const CLUSTER_KV = env.CLUSTER_KV;
-
-  if (!CLUSTER_KV) {
-    return jsonErrorResponse("KV store not configured", 500, sourceName);
-  }
-
-  let ttl_seconds = 6 * 60 * 60; // 6 hours (21600 seconds)
-  if (env.CLUSTER_DEFINITION_TTL_SECONDS) {
-    const parsed = parseInt(env.CLUSTER_DEFINITION_TTL_SECONDS, 10);
-    if (!isNaN(parsed) && parsed > 0) {
-      ttl_seconds = parsed;
-    } else {
-      console.warn(`Invalid CLUSTER_DEFINITION_TTL_SECONDS value: "${env.CLUSTER_DEFINITION_TTL_SECONDS}". Using default: ${ttl_seconds}s.`);
-    }
-  }
-
-  if (request.method === "POST") {
-    try {
-      const { clusterId, earthquakeIds, strongestQuakeId } = await request.json();
-      if (!clusterId || !earthquakeIds || !Array.isArray(earthquakeIds) || earthquakeIds.length === 0 || !strongestQuakeId) {
-        return jsonErrorResponse("Missing or invalid parameters for POST", 400, sourceName);
-      }
-      const valueToStore = {
-        earthquakeIds,
-        strongestQuakeId,
-        updatedAt: new Date().toISOString()
-      };
-      const kvValue = JSON.stringify(valueToStore);
-      await CLUSTER_KV.put(clusterId, kvValue, { expirationTtl: ttl_seconds });
-      return new Response(JSON.stringify({ status: "success", message: "Cluster definition stored." }), {
-        status: 201,
-        headers: { "Content-Type": "application/json" },
-      });
-    } catch (e) {
-      console.error("Error processing POST for cluster definition:", e);
-      return jsonErrorResponse(`Error processing request: ${e.message}`, 500, sourceName);
-    }
-  } else if (request.method === "GET") {
-    const clusterId = url.searchParams.get("id");
-    if (!clusterId) {
-      return jsonErrorResponse("Missing 'id' query parameter for GET", 400, sourceName);
-    }
-    try {
-      const kvValue = await CLUSTER_KV.get(clusterId);
-      if (kvValue === null) {
-        return jsonErrorResponse("Cluster definition not found.", 404, sourceName);
-      }
-      return new Response(kvValue, {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-    } catch (e) {
-      console.error("Error processing GET for cluster definition:", e);
-      return jsonErrorResponse(`Error processing request: ${e.message}`, 500, sourceName);
-    }
-  } else {
-    return jsonErrorResponse("Method not allowed", 405, sourceName);
-  }
-}
-
 async function handleUsgsProxyRequest(context, apiUrl) {
   const sourceName = "usgs-proxy-handler";
   const cacheKey = new Request(apiUrl, context.request);
@@ -363,40 +300,29 @@ export async function handleEarthquakesSitemapRequest(context) {
 // 4. Clusters Sitemap Endpoint (/sitemap-clusters.xml)
 export async function handleClustersSitemapRequest(context) {
   const sourceName = "clusters-sitemap-handler";
-  const CLUSTER_KV = context.env.CLUSTER_KV;
+  const DB = context.env.DB;
   let clustersXml = "";
   const currentDate = new Date().toISOString(); // For lastmod fallback
 
-  if (!CLUSTER_KV) {
-    console.error(`[${sourceName}] CLUSTER_KV not available`);
-    return new Response(`<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n<!-- CLUSTER_KV not available -->\n</urlset>`, {
+  if (!DB) {
+    console.error(`[${sourceName}] D1 Database (DB) not available`);
+    return new Response(`<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n<!-- D1 Database not available -->\n</urlset>`, {
       headers: { "Content-Type": "application/xml", "Cache-Control": "public, max-age=3600" }, // Cache error for 1 hour
     });
   }
 
   try {
-    const listResult = await CLUSTER_KV.list({ limit: 500 }); // Limit to 500 keys
+    // Fetch clusterId and updatedAt from ClusterDefinitions table
+    // Assuming columns are named clusterId and updatedAt. Adjust if necessary.
+    const stmt = DB.prepare("SELECT clusterId, updatedAt FROM ClusterDefinitions ORDER BY updatedAt DESC LIMIT 500");
+    const { results } = await stmt.all();
 
-    if (listResult && listResult.keys) {
-      for (const key of listResult.keys) {
-        const loc = `https://earthquakeslive.com/cluster/${escapeXml(key.name)}`;
-        let lastmod = currentDate; // Fallback to current date
-
-        try {
-          const kvValueString = await CLUSTER_KV.get(key.name);
-          if (kvValueString) {
-            const kvValue = JSON.parse(kvValueString);
-            if (kvValue && kvValue.updatedAt) {
-              lastmod = kvValue.updatedAt;
-            } else {
-              console.warn(`[${sourceName}] Missing updatedAt for cluster key: ${key.name}. Falling back to currentDate.`);
-            }
-          } else {
-            console.warn(`[${sourceName}] No KV value found for cluster key: ${key.name} during sitemap generation. Falling back to currentDate.`);
-          }
-        } catch (e) {
-          console.error(`[${sourceName}] Error parsing KV value for cluster key ${key.name}: ${e.message}. Falling back to currentDate.`, e);
-        }
+    if (results && results.length > 0) {
+      for (const row of results) {
+        const loc = `https://earthquakeslive.com/cluster/${escapeXml(row.clusterId)}`;
+        // Ensure updatedAt is a valid ISO string. If it's already stored as ISO, no conversion needed.
+        // If it's a number (timestamp) or different format, it might need new Date(row.updatedAt).toISOString()
+        const lastmod = row.updatedAt ? new Date(row.updatedAt).toISOString() : currentDate;
 
         clustersXml += `
   <url>
@@ -407,11 +333,11 @@ export async function handleClustersSitemapRequest(context) {
   </url>`;
       }
     } else {
-      console.log(`[${sourceName}] No cluster keys found or listResult is empty.`);
+      console.log(`[${sourceName}] No cluster definitions found in D1 table ClusterDefinitions.`);
     }
   } catch (error) {
-    console.error(`[${sourceName}] Exception listing or processing cluster keys: ${error.message}`, error);
-    return new Response(`<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n<!-- Exception processing cluster data: ${escapeXml(error.message)} -->\n</urlset>`, {
+    console.error(`[${sourceName}] Exception querying or processing cluster data from D1: ${error.message}`, error);
+    return new Response(`<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n<!-- Exception processing cluster data from D1: ${escapeXml(error.message)} -->\n</urlset>`, {
       headers: { "Content-Type": "application/xml", "Cache-Control": "public, max-age=3600" }, // Cache error for 1 hour
     });
   }
@@ -585,8 +511,9 @@ export async function handlePrerenderCluster(context, clusterId) {
   const sourceName = "prerender-cluster";
   const siteUrl = "https://earthquakeslive.com"; // Base site URL
 
-  if (!env.CLUSTER_KV) {
-    console.error(`[${sourceName}] CLUSTER_KV not configured.`);
+  // Using env.DB for D1 access, env.CLUSTER_KV is no longer used here.
+  if (!env.DB) {
+    console.error(`[${sourceName}] D1 Database (env.DB) not configured for prerendering cluster.`);
     return new Response(`<!DOCTYPE html><html><head><title>Error</title><meta name="robots" content="noindex"></head><body>Service configuration error.</body></html>`, {
       status: 500,
       headers: {
@@ -598,10 +525,13 @@ export async function handlePrerenderCluster(context, clusterId) {
 
   try {
     console.log(`[${sourceName}] Prerendering cluster: ${clusterId}`);
-    const clusterDataString = await env.CLUSTER_KV.get(clusterId);
+    // Fetch cluster data from D1 table ClusterDefinitions
+    // Assuming table `ClusterDefinitions` and columns `clusterId`, `earthquakeIds`, `strongestQuakeId`, `updatedAt`
+    const stmt = env.DB.prepare("SELECT earthquakeIds, strongestQuakeId, updatedAt FROM ClusterDefinitions WHERE clusterId = ?").bind(clusterId);
+    const clusterInfo = await stmt.first();
 
-    if (!clusterDataString) {
-      console.warn(`[${sourceName}] Cluster definition not found for ID: ${clusterId}`);
+    if (!clusterInfo) {
+      console.warn(`[${sourceName}] Cluster definition not found in D1 for ID: ${clusterId}`);
       return new Response(`<!DOCTYPE html><html><head><title>Not Found</title><meta name="robots" content="noindex"></head><body>Cluster not found.</body></html>`, {
         status: 404,
         headers: {
@@ -611,8 +541,20 @@ export async function handlePrerenderCluster(context, clusterId) {
       });
     }
 
-    const clusterData = JSON.parse(clusterDataString);
-    const { earthquakeIds, strongestQuakeId, updatedAt } = clusterData;
+    // earthquakeIds might be stored as JSON string in D1, parse if needed.
+    // Or it might be retrieved directly if D1 supports JSON types well and wrangler config is right.
+    // For this example, assuming earthquakeIds is retrieved as a string that needs parsing.
+    // Adjust if earthquakeIds is stored/retrieved differently (e.g. as a native JSON type or serialized differently).
+    let earthquakeIds;
+    try {
+        earthquakeIds = typeof clusterInfo.earthquakeIds === 'string' ? JSON.parse(clusterInfo.earthquakeIds) : clusterInfo.earthquakeIds;
+    } catch (e) {
+        console.error(`[${sourceName}] Error parsing earthquakeIds for cluster ${clusterId}: ${e.message}`);
+        return new Response(`<!DOCTYPE html><html><head><title>Error</title><meta name="robots" content="noindex"></head><body>Error processing cluster data.</body></html>`, {
+            status: 500, headers: { "Content-Type": "text/html", "Cache-Control": "public, s-maxage=3600" }
+        });
+    }
+    const { strongestQuakeId, updatedAt } = clusterInfo;
     const numEvents = earthquakeIds ? earthquakeIds.length : 0;
     const canonicalUrl = `${siteUrl}/cluster/${clusterId}`;
     const formattedUpdatedAt = new Date(updatedAt).toLocaleString('en-US', {
@@ -791,9 +733,7 @@ export async function onRequest(context) {
   }
 
   // Existing API routes
-  else if (pathname === "/api/cluster-definition") {
-    return handleClusterDefinitionRequest(context, url);
-  } else if (pathname === "/api/usgs-proxy") {
+  else if (pathname === "/api/usgs-proxy") {
     const apiUrl = url.searchParams.get("apiUrl");
     if (!apiUrl) {
       return jsonErrorResponse("Missing apiUrl query parameter for proxy request", 400, "usgs-proxy-router");

--- a/functions/api/calculate-clusters.test.js
+++ b/functions/api/calculate-clusters.test.js
@@ -1,0 +1,216 @@
+import { onRequestPost } from './calculate-clusters'; // Adjust path as needed
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// Helper to create mock context for calculate-clusters
+const createMockContext = (requestBody, envOverrides = {}) => {
+  const mockDbInstance = {
+    prepare: vi.fn().mockReturnThis(), // Ensure prepare() returns the mock itself for chaining
+    bind: vi.fn().mockReturnThis(),   // Ensure bind() returns the mock itself
+    first: vi.fn(),
+    run: vi.fn(),
+    all: vi.fn(), // Though not used by calculate-clusters, good for a generic mock
+  };
+
+  return {
+    request: {
+      json: vi.fn().mockResolvedValue(requestBody),
+    },
+    env: {
+      DB: mockDbInstance, // Default mock DB
+      ...envOverrides,
+    },
+    // Add other context properties if your function uses them (e.g., waitUntil)
+  };
+};
+
+describe('onRequestPost in calculate-clusters.js', () => {
+  const mockEarthquakes = [{ id: 'q1', properties: { mag: 1 }, geometry: { coordinates: [0, 0, 0] } }];
+  const defaultRequestBody = {
+    earthquakes: mockEarthquakes,
+    maxDistanceKm: 100,
+    minQuakes: 1,
+    lastFetchTime: '2024-01-01T00:00:00Z',
+    timeWindowHours: 24,
+  };
+  const expectedCacheKeyParams = {
+      numQuakes: mockEarthquakes.length,
+      maxDistanceKm: defaultRequestBody.maxDistanceKm,
+      minQuakes: defaultRequestBody.minQuakes,
+      lastFetchTime: defaultRequestBody.lastFetchTime,
+      timeWindowHours: defaultRequestBody.timeWindowHours
+  };
+  const expectedCacheKey = `clusters-${JSON.stringify(expectedCacheKeyParams)}`;
+
+
+  beforeEach(() => {
+    vi.resetAllMocks(); // Reset mocks before each test
+  });
+
+  it('should return 400 if earthquakes array is missing or empty', async () => {
+    const context = createMockContext({ ...defaultRequestBody, earthquakes: [] });
+    const response = await onRequestPost(context);
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toBe('Invalid or empty earthquakes array');
+  });
+
+  it('should return 400 if maxDistanceKm is invalid', async () => {
+    const context = createMockContext({ ...defaultRequestBody, maxDistanceKm: 0 });
+    const response = await onRequestPost(context);
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toBe('Invalid maxDistanceKm');
+  });
+
+  it('should return 400 if minQuakes is invalid', async () => {
+    const context = createMockContext({ ...defaultRequestBody, minQuakes: 0 });
+    const response = await onRequestPost(context);
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toBe('Invalid minQuakes');
+  });
+
+  it('should calculate clusters and return data if DB is not configured, with X-Cache-Info header', async () => {
+    const context = createMockContext(defaultRequestBody, { DB: undefined });
+    const response = await onRequestPost(context);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(Array.isArray(json)).toBe(true); // Basic check for cluster data
+    expect(response.headers.get('X-Cache-Hit')).toBe('false');
+    expect(response.headers.get('X-Cache-Info')).toBe('DB not configured');
+  });
+
+  it('should return cached data if valid entry exists in D1', async () => {
+    const mockCachedClusterData = [{ id: 'cluster1', quakes: ['q1'] }];
+    const context = createMockContext(defaultRequestBody);
+    context.env.DB.first.mockResolvedValueOnce({ clusterData: JSON.stringify(mockCachedClusterData) });
+
+    const response = await onRequestPost(context);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json).toEqual(mockCachedClusterData);
+    expect(response.headers.get('X-Cache-Hit')).toBe('true');
+    expect(context.env.DB.prepare).toHaveBeenCalledWith(expect.stringContaining("SELECT clusterData FROM ClusterCache WHERE cacheKey = ? AND createdAt > datetime('now', '-1 hour')"));
+    expect(context.env.DB.bind).toHaveBeenCalledWith(expectedCacheKey);
+    expect(context.env.DB.run).not.toHaveBeenCalled(); // Should not insert
+  });
+
+  it('should calculate, store, and return data if cache miss (D1 returns null)', async () => {
+    const context = createMockContext(defaultRequestBody);
+    context.env.DB.first.mockResolvedValueOnce(null); // Cache miss
+    context.env.DB.run.mockResolvedValueOnce({ success: true }); // Mock successful insert
+
+    const response = await onRequestPost(context);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(Array.isArray(json)).toBe(true); // Basic check
+    expect(response.headers.get('X-Cache-Hit')).toBe('false');
+
+    expect(context.env.DB.prepare).toHaveBeenCalledWith(expect.stringContaining("SELECT clusterData FROM ClusterCache"));
+    expect(context.env.DB.bind).toHaveBeenCalledWith(expectedCacheKey);
+    expect(context.env.DB.prepare).toHaveBeenCalledWith(expect.stringContaining("INSERT OR REPLACE INTO ClusterCache"));
+    expect(context.env.DB.bind).toHaveBeenCalledWith(expectedCacheKey, JSON.stringify(json));
+    expect(context.env.DB.run).toHaveBeenCalled();
+  });
+
+  it('should calculate, store, and return data if cached data is invalid JSON', async () => {
+    const context = createMockContext(defaultRequestBody);
+    context.env.DB.first.mockResolvedValueOnce({ clusterData: "invalid json" }); // Invalid JSON in cache
+    context.env.DB.run.mockResolvedValueOnce({ success: true });
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+
+    const response = await onRequestPost(context);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(Array.isArray(json)).toBe(true);
+    expect(response.headers.get('X-Cache-Hit')).toBe('false');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error parsing cached JSON from D1:', expect.any(Error));
+    expect(context.env.DB.run).toHaveBeenCalled(); // Should re-calculate and store
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should calculate and return data if D1 SELECT fails, without caching', async () => {
+    const context = createMockContext(defaultRequestBody);
+    context.env.DB.first.mockRejectedValueOnce(new Error('D1 SELECT failed'));
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const response = await onRequestPost(context);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(Array.isArray(json)).toBe(true);
+    expect(response.headers.get('X-Cache-Hit')).toBe('false');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('D1 GET error:', expect.any(Error));
+    // Should still attempt to store if SELECT fails but calculation succeeds
+    expect(context.env.DB.prepare).toHaveBeenCalledWith(expect.stringContaining("INSERT OR REPLACE"));
+    expect(context.env.DB.run).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should calculate and return data if D1 INSERT fails, header X-Cache-Hit false', async () => {
+    const context = createMockContext(defaultRequestBody);
+    context.env.DB.first.mockResolvedValueOnce(null); // Cache miss
+    context.env.DB.run.mockRejectedValueOnce(new Error('D1 INSERT failed')); // Insert fails
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+
+    const response = await onRequestPost(context);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(Array.isArray(json)).toBe(true);
+    expect(response.headers.get('X-Cache-Hit')).toBe('false');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('D1 PUT error:', expect.any(Error));
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should handle syntax error in request JSON', async () => {
+    const context = createMockContext(null); // requestBody is null
+    context.request.json.mockRejectedValueOnce(new SyntaxError("Unexpected token")); // Simulate JSON parse error
+    const response = await onRequestPost(context);
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toBe('Invalid JSON payload');
+  });
+
+  it('should handle generic error during processing', async () => {
+    const problematicEarthquakes = [
+      { id: 'q1', properties: { mag: 1 }, geometry: { coordinates: [0, 0, 0] } },
+      { id: 'q2', properties: { mag: 2 }, geometry: null }, // This will cause an error in findActiveClusters
+    ];
+    const requestBodyWithError = {
+      ...defaultRequestBody,
+      earthquakes: problematicEarthquakes,
+    };
+    // Generate a unique cache key for this specific problematic input
+    const errorCacheKeyParams = {
+        numQuakes: problematicEarthquakes.length,
+        maxDistanceKm: defaultRequestBody.maxDistanceKm,
+        minQuakes: defaultRequestBody.minQuakes,
+        lastFetchTime: defaultRequestBody.lastFetchTime,
+        timeWindowHours: defaultRequestBody.timeWindowHours
+    };
+    const errorCacheKey = `clusters-${JSON.stringify(errorCacheKeyParams)}`;
+
+    const context = createMockContext(requestBodyWithError);
+    // Ensure it's a cache miss for this specific cache key
+    context.env.DB.prepare.mockImplementation((query) => {
+        if (query.includes("SELECT clusterData FROM ClusterCache")) {
+            return { bind: vi.fn((key) => {
+                if (key === errorCacheKey) {
+                    return { first: vi.fn().mockResolvedValueOnce(null) };
+                }
+                return { first: vi.fn().mockResolvedValueOnce({ clusterData: "[]" }) }; // Default for other keys
+            })};
+        }
+        return { bind: vi.fn().mockReturnThis(), run: vi.fn().mockResolvedValueOnce({ success: true }) };
+    });
+
+
+    const response = await onRequestPost(context);
+    expect(response.status).toBe(500);
+    const json = await response.json();
+    expect(json.error).toBe('Internal server error');
+    // Check if the details message indicates a TypeError, which is likely from accessing properties of null
+    expect(json.details).toMatch(/TypeError|Cannot read properties of null/i);
+  });
+});

--- a/migrations/0001_create_cluster_cache_table.sql
+++ b/migrations/0001_create_cluster_cache_table.sql
@@ -1,0 +1,13 @@
+-- Migration script to create the ClusterCache table for D1
+-- This table will store cached cluster calculation results.
+
+DROP TABLE IF EXISTS ClusterCache;
+
+CREATE TABLE ClusterCache (
+    cacheKey TEXT PRIMARY KEY NOT NULL,    -- Unique key for the cache entry (e.g., derived from lastFetchTime and timeWindowHours)
+    clusterData TEXT NOT NULL,             -- JSON string containing the calculated cluster data
+    createdAt DATETIME DEFAULT CURRENT_TIMESTAMP -- Timestamp of when the cache entry was created
+);
+
+-- Optional: Index on createdAt for efficient querying of stale entries if needed in the future
+-- CREATE INDEX IF NOT EXISTS idx_clusterCache_createdAt ON ClusterCache(createdAt);


### PR DESCRIPTION
This commit migrates data storage and caching mechanisms from Kv to D1 to align with the application's shift towards D1.

Changes include:

- Resolved cluster definition conflict:
    - Removed Kv-based `handleClusterDefinitionRequest` from `functions/[[catchall]].js`.
    - Ensured `functions/api/cluster-definition.js` (D1-based) is the sole handler for these operations.
- Migrated cluster calculation caching:
    - Created a new D1 table `ClusterCache`.
    - Updated `functions/api/calculate-clusters.js` to use this D1 table for caching, replacing Kv.
    - The API for `calculate-clusters` now expects `lastFetchTime` and `timeWindowHours` in the request body for improved cache key specificity.
- Migrated cluster sitemap generation:
    - Updated `handleClustersSitemapRequest` in `functions/[[catchall]].js` to fetch cluster data from the D1 `ClusterDefinitions` table instead of Kv.
- Migrated cluster page prerendering:
    - Updated `handlePrerenderCluster` in `functions/[[catchall]].js` to fetch cluster data from the D1 `ClusterDefinitions` table instead of Kv.
- Reviewed `wrangler.toml`:
    - Kept the `CLUSTER_KV` namespace binding as per your request.
    - Confirmed D1 bindings are correctly configured.
- Added and updated tests:
    - Created new tests for `functions/api/calculate-clusters.js`.
    - Updated existing tests in `functions/[[catchall]].test.js` to reflect D1 usage for sitemap and prerendering.
    - Ensured all tests pass and the build completes successfully.