### PR TITLE
Refactor earthquake detail page for D1 and new URL structure

### DIFF
--- a/src/components/EarthquakeDetailModalComponent.jsx
+++ b/src/components/EarthquakeDetailModalComponent.jsx
@@ -48,7 +48,33 @@ const EarthquakeDetailModalComponent = () => {
 
     const params = useParams();
     const navigate = useNavigate();
-    const detailUrlParam = params['*']; const detailUrl = typeof detailUrlParam === 'string' ? decodeURIComponent(detailUrlParam) : undefined;
+    const detailUrlParam = params['*']; // This is our slug e.g. m6.5-northern-california-nc73649170
+
+    // New logic to construct detailUrl from usgs-id
+    let detailUrl;
+    if (detailUrlParam) {
+        const parts = detailUrlParam.split('-');
+        if (parts.length > 1) {
+            const usgsId = parts[parts.length - 1];
+            if (usgsId) {
+                detailUrl = `https://earthquake.usgs.gov/earthquakes/feed/v1.0/detail/${usgsId}.geojson`;
+            } else {
+                // This case should ideally not happen if format is correct, but good to be aware
+                console.warn(`EarthquakeDetailModalComponent: Extracted usgsId is empty from param: ${detailUrlParam}`);
+                // Fallback to trying to decode the whole thing, though this is less likely to be a valid GeoJSON URL
+                detailUrl = typeof detailUrlParam === 'string' ? decodeURIComponent(detailUrlParam) : undefined;
+            }
+        } else {
+            console.warn(`EarthquakeDetailModalComponent: Unexpected format for detailUrlParam: ${detailUrlParam}. Expected format like 'm[magnitude]-[location-slug]-[usgs-id]'.`);
+            // Fallback: try to use the decoded param directly if it doesn't match the new format.
+            // This might be an old full URL or some other format.
+            detailUrl = typeof detailUrlParam === 'string' ? decodeURIComponent(detailUrlParam) : undefined;
+        }
+    } else {
+        console.warn("EarthquakeDetailModalComponent: detailUrlParam is undefined.");
+        detailUrl = undefined;
+    }
+
     const [seoProps, setSeoProps] = useState(null); // Renamed from seoData to seoProps
 
     const handleClose = () => {
@@ -92,7 +118,8 @@ const EarthquakeDetailModalComponent = () => {
         const pageDescription = `Detailed report of the M ${mag} earthquake that struck near ${place} on ${titleDate} at ${descriptionTime} (UTC). Magnitude: ${mag}, Depth: ${depth} km. Location: ${latitude?.toFixed(2)}, ${longitude?.toFixed(2)}. Stay updated with Earthquakes Live.`;
 
         const pageKeywords = `earthquake, seismic event, M ${mag}, ${place ? place.split(', ').join(', ') : ''}, earthquake details, usgs event, ${usgsEventId}`;
-        const canonicalPageUrl = `https://earthquakeslive.com/quake/${params['*']}`; // detailUrlParam is from useParams()
+        // canonicalPageUrl uses detailUrlParam (which is params['*']) directly as per requirements.
+        const canonicalPageUrl = `https://earthquakeslive.com/quake/${detailUrlParam}`;
 
         const eventLocation = {
             '@type': 'Place',
@@ -137,14 +164,14 @@ const EarthquakeDetailModalComponent = () => {
             modifiedTime: updated ? new Date(updated).toISOString() : (time ? new Date(time).toISOString() : undefined),
             imageUrl: shakemapIntensityImageUrl || null,
         });
-    }, [detailUrlParam]);
+    }, [detailUrlParam]); // detailUrlParam (params['*']) is a dependency for canonicalPageUrl
 
     // Default/loading SEO values
     const initialPageTitle = "Loading Earthquake Details... | Earthquakes Live";
     const initialPageDescription = "Fetching detailed information for the selected seismic event.";
     const initialKeywords = "earthquake details, seismic event, seismology, earthquakes live";
-    // detailUrlParam might be undefined on initial render if component loads before router is fully ready.
-    const initialCanonicalUrl = params['*'] ? `https://earthquakeslive.com/quake/${params['*']}` : "https://earthquakeslive.com";
+    // initialCanonicalUrl uses detailUrlParam (params['*']) directly as per requirements.
+    const initialCanonicalUrl = detailUrlParam ? `https://earthquakeslive.com/quake/${detailUrlParam}` : "https://earthquakeslive.com";
 
 
     return (


### PR DESCRIPTION
This commit implements changes to shift the earthquake detail page to a new URL structure and refactors data fetching to prioritize D1 with a fallback to the USGS API.

Key changes include:

1.  **New URL Structure**:
    *   Implemented URL structure `quake/m[magnitude]-[location-slug]-[usgs-id]`.
    *   Updated client-side routing and navigation in `HomePage.jsx` (`handleQuakeClick`, `handleNotableQuakeSelect`) to generate these new URLs. A `slugify` helper function was added for creating location slugs.
    *   Modified `EarthquakeDetailModalComponent.jsx` to parse the `usgs-id` from the new URL slug and reconstruct the necessary USGS GeoJSON URL for the `EarthquakeDetailView` component.

2.  **D1 and USGS API Fetching**:
    *   Enhanced the `handleEarthquakeDetailRequest` Cloudflare function:
        *   It now first attempts to fetch earthquake data from the D1 database.
        *   If D1 is unavailable, the record is not found, the record is stale, or if the D1 query itself fails, the function robustly falls back to fetching data from the USGS API.
        *   Data fetched from USGS is asynchronously upserted into D1 for future requests (conditional on D1 being available).

3.  **Server-Side Updates**:
    *   **Prerendering**: The `handlePrerenderEarthquake` function in `functions/[[catchall]].js` was updated to correctly parse the `usgs-id` from the new URL slug format and fetch data for prerendering.
    *   **Sitemap**: The `handleEarthquakesSitemapRequest` function in `functions/[[catchall]].js` was updated to generate sitemap `<loc>` URLs using the new slug format. A `slugify` helper was also added to this file.

Work on adding and updating unit tests for these changes was about to begin but has been deferred. This includes tests for URL parsing, slug generation, and the updated logic in the Cloudflare Functions for prerendering, sitemap generation, and D1 fallback.