### PR TITLE
Fix: Correct wrangler.toml schedules configuration

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -94,7 +94,7 @@ preview_database_id = "57ba069c-5763-41c3-965d-0df87b0ef26b" # For `wrangler pag
 [env.dev.d1_databases]
 DB = { preview_database_id = "57ba069c-5763-41c3-965d-0df87b0ef26b" }
 
-[schedules]
+[triggers]
 crons = ["*/1 * * * *"] # Run every minute
 
 # If you have other bindings (like R2, Services), define them here too.


### PR DESCRIPTION
The field `schedules` is not a valid top-level field for configuring cron jobs in `wrangler.toml`. This commit moves the `crons` definition from the `[schedules]` table to the correct `[triggers]` table as per the Cloudflare Wrangler documentation.

This change resolves the warning: "Unexpected fields found in top-level field: schedules".