### PR TITLE
refactor: Move deployment scripts to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,50 @@ The application leverages Cloudflare's robust infrastructure for both frontend h
     *   **Cost-Effectiveness**: Serverless architecture can be more cost-effective as you only pay for what you use.
     *   **Simplified DevOps**: CI/CD for the frontend is streamlined through Cloudflare Pages' integration with Git repositories.
 
+## Environments and Deployment
+
+This project utilizes distinct environments for development, staging, and production, managed through Cloudflare Pages and Wrangler.
+
+### Environments
+
+*   **`production`**: This is the live environment that serves the application to end-users. It uses production-ready configurations, including the main D1 database and KV namespaces.
+*   **`staging`**: This environment is intended for pre-production testing. It mirrors the production setup and, importantly, **uses the same production D1 database and KV namespace bindings**. This allows for testing with live data to ensure changes are safe and performant before they are deployed to the live `production` environment. Use this environment with caution due to its use of live data.
+*   **`preview`**: Cloudflare Pages automatically generates preview deployments for each commit pushed to a branch (other than the production branch). These environments use preview-specific D1 and KV namespaces, suitable for testing new features in isolation without affecting production or staging data.
+*   **`dev`**: This refers to the local development environment when using `wrangler pages dev` or `vite`. It typically uses preview or development-specific bindings defined in `wrangler.toml` to avoid impacting live data.
+
+### Manual Deployment Commands
+
+Manual deployments to specific environments can be performed using npm or yarn scripts defined in `package.json`.
+
+*   **Deploying to Staging**:
+    *   **Purpose**: Deploys the current state of your project to the `staging` environment on Cloudflare.
+    *   **npm Command**: `npm run deploy:staging`
+    *   **Yarn Command**: `yarn deploy:staging`
+    *   **Usage**: Run the appropriate command from your terminal to push changes to staging. This is useful for final testing before a production release.
+    ```bash
+    # Using npm
+    npm run deploy:staging
+
+    # Or using Yarn
+    yarn deploy:staging
+    ```
+
+*   **Deploying to Production**:
+    *   **Purpose**: Deploys the current state of your project to the `production` (live) environment on Cloudflare.
+    *   **npm Command**: `npm run deploy:production`
+    *   **Yarn Command**: `yarn deploy:production`
+    *   **Usage**: Run the appropriate command from your terminal to push changes to production. This should only be done after changes have been thoroughly tested (e.g., in `staging` or preview deployments).
+    ```bash
+    # Using npm
+    npm run deploy:production
+
+    # Or using Yarn
+    yarn deploy:production
+    ```
+
+**Note on Automated Deployments:**
+Typically, the `production` environment is connected to the main branch of the Git repository, and deployments to production occur automatically when changes are merged into that branch. The `staging` environment might also be configured for automatic deployments from a specific branch (e.g., `develop` or `staging`), or manual deployments using the commands above can be used as part of the release process. Preview deployments are almost always automated by Cloudflare Pages.
+
 ## Development Journey & Concept: "Vibe-Coding" with Gemini Canvas
 
 This Global Seismic Activity Monitor was brought to life through a dynamic and iterative development process, affectionately termed "vibe-coding." The project was conceptualized and significantly shaped within Gemini Canvas, leveraging a conversational AI-assisted development workflow.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview",
     "test": "vitest",
     "docs": "npx jsdoc -c jsdoc.json",
-    "deploy": "wrangler deploy src/worker.js"
+    "deploy": "wrangler deploy src/worker.js",
+    "deploy:staging": "npx wrangler deploy --env staging",
+    "deploy:production": "npx wrangler deploy --env production"
   },
   "dependencies": {
     "leaflet": "^1.9.4",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -57,6 +57,20 @@ run_worker_first = true
 [env.dev.kv_namespaces]
 CLUSTER_KV = { preview_id = "25424bdebf90459ea61121e9b3dfc4ee" }
 
+
+# Staging environment configuration
+# Inherits from top-level, uses production KV and D1 bindings
+[env.staging]
+# For KV, staging uses the production ID
+kv_namespaces = [
+  { binding = "CLUSTER_KV", id = "2e7c7b5faf2f47868a048bd8043edebc" }
+]
+# For D1, staging uses the production database_id
+d1_databases = [
+  { binding = "DB", database_name = "PrimaryDB", database_id = "8a0a26e9-ba3c-4984-9023-c1803f611a05" }
+]
+
+
 # D1 Database binding for primary data
 # -----------------------------------------------------------------------------------------
 # IMPORTANT INSTRUCTIONS FOR THE USER:
@@ -93,6 +107,7 @@ preview_database_id = "57ba069c-5763-41c3-965d-0df87b0ef26b" # For `wrangler pag
 # or a specific local/dev D1 instance ID if you have one.
 [env.dev.d1_databases]
 DB = { preview_database_id = "57ba069c-5763-41c3-965d-0df87b0ef26b" }
+
 
 [triggers]
 crons = ["*/1 * * * *"] # Run every minute


### PR DESCRIPTION
This commit refactors the deployment process by moving the deployment commands into the `scripts` section of `package.json`.

Key changes:
- Added `deploy:staging` and `deploy:production` scripts to `package.json`. These scripts utilize `npx wrangler deploy` with the appropriate environment flag.
- Updated `README.md` to reflect the new deployment method using `npm run deploy:<env>` or `yarn deploy:<env>`.
- Removed the now-redundant `deploy-staging.sh` and `deploy-production.sh` shell script files.

This change centralizes project scripts within `package.json`, making them more discoverable and aligned with common Node.js project practices.