### PR TITLE
Fix: Explicitly set name in wrangler.toml for staging

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -75,6 +75,7 @@ CLUSTER_KV = { preview_id = "25424bdebf90459ea61121e9b3dfc4ee" }
 # Staging environment configuration
 # Inherits from top-level, uses production KV and D1 bindings
 [env.staging]
+name = "earthquake" # Explicitly set name for staging environment
 main = "src/worker.js"
 # For KV, staging uses the production ID. This is consistent with original.
 kv_namespaces = [


### PR DESCRIPTION
Addresses a CI warning where the name was reportedly mismatched. The CI expected "earthquake", but believed the config file specified "earthquake-staging" when evaluating the staging environment.

This change explicitly adds `name = "earthquake"` to the `[env.staging]` section in `wrangler.toml`. This ensures that the staging environment configuration clearly defines its name as "earthquake", aligning with the top-level declaration and the CI's expectation.