### PR TITLE
Fix: Explicitly set my name for production environment

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -48,6 +48,7 @@ run_worker_first = true
 
 # Production environment configuration
 [env.production]
+name = "earthquake" # Explicitly set name for production environment
 main = "src/worker.js"
 workers_dev = true # Set to false if using custom domain for production and not workers.dev
 kv_namespaces = [


### PR DESCRIPTION
This commit extends the previous fix for CI name mismatches to include the [env.production] configuration in wrangler.toml.

Following a similar CI warning that indicated a mismatch for "earthquake-production" vs the expected "earthquake", this change explicitly adds `name = "earthquake"` to the `[env.production]` section. This ensures that the production environment configuration clearly defines my name as "earthquake", aligning with the top-level declaration, the staging environment's explicit setting, and the CI's overall expectation.