### PR TITLE
Fix: Configure preview environment in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -46,6 +46,26 @@ run_worker_first = true
 #    with `wrangler dev`.
 # -----------------------------------------------------------------------------------------
 
+[env.preview]
+name = "earthquake-preview" # It's good practice to give preview a distinct name
+main = "src/worker.js"
+workers_dev = true # Assuming preview might also use a *.workers.dev subdomain initially
+
+# Use preview specific IDs for bindings
+kv_namespaces = [
+  { binding = "CLUSTER_KV", preview_id = "25424bdebf90459ea61121e9b3dfc4ee" }
+]
+d1_databases = [
+  { binding = "DB", database_name = "PrimaryDB", preview_database_id = "57ba069c-5763-41c3-965d-0df87b0ef26b" }
+]
+
+# Explicitly define how assets are handled for preview, mirroring top-level or production
+[env.preview.assets]
+directory = "./dist"
+not_found_handling = "single-page-application"
+binding = "ASSETS" # This might be optional if inherited, but explicit is safer.
+run_worker_first = true
+
 # Production environment configuration
 [env.production]
 name = "earthquake" # Explicitly set name for production environment


### PR DESCRIPTION
The `wrangler versions upload` command for the preview environment was failing with an error: "Cannot use assets with a binding in an assets-only Worker."

This occurred because the preview environment was likely inheriting a top-level configuration that lacked a `main` script, causing it to be treated as an assets-only deployment. However, top-level bindings (KV, D1) were still present, leading to a conflict.

This commit adds an explicit `[env.preview]` section to `wrangler.toml`. This section defines:
- `main = "src/worker.js"` to specify the script.
- `name = "earthquake-preview"`.
- `workers_dev = true`.
- KV and D1 bindings configured to use their respective `preview_id`s, mirroring the `dev` environment setup for preview-specific resources.
- An `[env.preview.assets]` section to ensure consistent asset handling.

This change ensures that the preview environment is correctly recognized as having a script, resolving the deployment error.