### PR TITLE
Fix: Adjust wrangler.toml to resolve Pages deployment error

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -60,13 +60,6 @@ d1_databases = [
   { binding = "DB", database_name = "PrimaryDB", preview_database_id = "57ba069c-5763-41c3-965d-0df87b0ef26b" }
 ]
 
-# Explicitly define how assets are handled for preview, mirroring top-level or production
-[env.preview.assets]
-directory = "./dist"
-not_found_handling = "single-page-application"
-binding = "ASSETS" # This might be optional if inherited, but explicit is safer.
-run_worker_first = true
-
 # Production environment configuration
 [env.production]
 name = "earthquake" # Explicitly set name for production environment


### PR DESCRIPTION
The Cloudflare Pages preview environment was failing with the error: "Cannot use assets with a binding in an assets-only Worker."

This occurred despite `main = "src/worker.js"` being defined, indicating it's not an assets-only worker. The script at `src/worker.js` uses `env.ASSETS.fetch()` and thus requires `binding = "ASSETS"` in the assets configuration.

This commit modifies `wrangler.toml` by:
1. Ensuring the global `[assets]` configuration includes `binding = "ASSETS"`, `directory = "./dist"`, and `run_worker_first = true`.
2. Removing the specific `[env.preview.assets]` subsection.

The hypothesis is that the preview environment will inherit the global `[assets]` configuration. This simplification aims to prevent the `wrangler versions upload` command (used by Cloudflare Pages) from misinterpreting the configuration and triggering the error, while still providing the necessary `ASSETS` binding to the script.