### PR TITLE
Fix: Align proxy cache with 1-minute refresh interval for frontend

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -99,7 +99,7 @@ async function handleUsgsProxyRequest(request, env, ctx, apiUrl) {
       }));
     }
 
-    const DEFAULT_CACHE_DURATION_SECONDS = 600;
+    const DEFAULT_CACHE_DURATION_SECONDS = 60;
     let durationInSeconds = DEFAULT_CACHE_DURATION_SECONDS;
     const envCacheDuration = env.WORKER_CACHE_DURATION_SECONDS;
     if (envCacheDuration) {


### PR DESCRIPTION
Problem:
Your frontend was configured to refresh earthquake data every 1 minute. However, it fetched data via the `/api/usgs-proxy`, which had a default server-side cache of 10 minutes. This resulted in your frontend potentially receiving stale data.

Solution:
I changed the `DEFAULT_CACHE_DURATION_SECONDS` in the `handleUsgsProxyRequest` function within `src/worker.js` from 600 (10 minutes) to 60 (1 minute).

This change ensures that if the `WORKER_CACHE_DURATION_SECONDS` environment variable is not explicitly set, the default cache duration for proxied USGS feeds matches your frontend's 1-minute refresh cycle and the backend's 1-minute database update schedule.

This allows your frontend to display data that is updated every minute, in line with the application's requirements. The increased frequency of requests to USGS for client-initiated fetches is acceptable for a live data application of this nature.