### PR TITLE
I've updated the unit tests in `src/services/clusterApiService.test.j…

### DIFF
--- a/src/services/clusterApiService.js
+++ b/src/services/clusterApiService.js
@@ -191,32 +191,28 @@ export async function fetchActiveClusters(earthquakes, maxDistanceKm, minQuakes)
         // which was an older expectation for cacheHit === 'true' path.
         console.log(`Active clusters fetched from server (parsed as direct array). Cache-Hit: ${cacheHit}`);
         parsedClusters = data;
-      } else {
-        console.warn(`Unexpected data structure from server. Cache-Hit: ${cacheHit}. Will attempt local calculation.`);
-        // parsedClusters remains null, proceed to local calculation
       }
 
+      // If clusters were successfully parsed from server response, return them.
+      // Log whether it was a cache hit or not, but use the data regardless.
       if (parsedClusters !== null) {
-        if (cacheHit === 'true') {
-          // Successfully got valid cluster data from server cache
-          return parsedClusters;
-        } else {
-          // Server response was OK, data structure was valid, but it was not a cache hit (or header absent).
-          // The original logic implies falling back to local calculation in this case.
-          console.warn(`Server data received (Cache-Hit: ${cacheHit}), but policy is to fall back to local calculation for non-cache-hits or when X-Cache-Hit is not explicitly 'true'.`);
-          // Fall through to local calculation by not returning here.
-        }
+        console.log(`Using server data. Cache-Hit: ${cacheHit === 'true' ? 'true' : 'false or not present'}.`);
+        return parsedClusters;
+      } else {
+        // Server response was OK, but data structure was not as expected.
+        console.warn(`Unexpected data structure from server. Cache-Hit: ${cacheHit}. Falling back to local calculation.`);
+        // Fall through to local calculation by not returning here.
       }
-      // If parsedClusters is null (unexpected structure), fall through to local calculation.
-
     } else { // !response.ok
       const errorBody = await response.text();
       console.error(
         `Failed to fetch active clusters from server. Status: ${response.status}. Body: ${errorBody}. Falling back to local calculation.`
       );
+      // Fall through to local calculation.
     }
   } catch (error) {
-    console.error('Network error while fetching active clusters. Falling back to local calculation:', error);
+    console.error('Network error or JSON parsing error while fetching/processing active clusters. Falling back to local calculation:', error);
+    // Fall through to local calculation.
   }
 
   // Fallback to local calculation


### PR DESCRIPTION
…s` to align with the changes made to `fetchActiveClusters` regarding server data prioritization and fallback logic.

Modifications include:
- Adjusted tests for scenarios where `X-Cache-Hit` is 'false' or absent. These tests now correctly expect server data to be used if the server response is 200 OK and the data is valid, rather than falling back to local calculation. Test names and console log assertions have been updated accordingly.
- Added a new test case to verify that `fetchActiveClusters` falls back to local calculation if the server responds with 200 OK but the data payload has an unexpected or malformed structure.
- Ensured all console spy assertions (`log`, `warn`, `error`) accurately reflect the current behavior and messages from the `fetchActiveClusters` function for these scenarios.