### PR TITLE
Fix: Resolve build error by renaming export in calculate-clusters

### DIFF
--- a/functions/api/calculate-clusters.js
+++ b/functions/api/calculate-clusters.js
@@ -131,7 +131,7 @@ export function findActiveClusters(earthquakes, maxDistanceKm, minQuakes) {
  * @returns {Promise<Response>} A `Response` object containing either the calculated cluster data (Array of arrays of earthquake objects)
  *   or a JSON error object with appropriate HTTP status codes (400 for bad request, 500 for internal server error).
  */
-export async function onRequestPost(context) {
+export async function onRequest(context) {
   try {
     const { env } = context;
     const { earthquakes, maxDistanceKm, minQuakes, lastFetchTime, timeWindowHours } = await context.request.json();


### PR DESCRIPTION
The build process was failing with the error:
"No matching export in 'functions/api/calculate-clusters.POST.js' for import 'onRequest'"

This was caused by an import in `src/worker.js`:
`import { onRequest as handlePostCalculateClusters } from '../functions/api/calculate-clusters.POST.js';`

The file `functions/api/calculate-clusters.js` was exporting `onRequestPost` instead of `onRequest`. Cloudflare Pages Functions expect `onRequest` (or method-specific handlers like `onRequestPost` if not using the `.METHOD.js` file naming convention for the import path itself).

This commit renames the exported function `onRequestPost` to `onRequest` in `functions/api/calculate-clusters.js` to match the import and satisfy the build system's expectation for `.POST.js` suffixed imports.