### PR TITLE
Fix: Resolve build error and wrangler.toml migrations config

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -2,7 +2,7 @@
 // Note: Adjusted path assuming worker.js is in src/ and d1Utils.js is in src/utils/
 import { upsertEarthquakeFeaturesToD1 } from './utils/d1Utils.js';
 import { onRequestGet as handleGetClusterWithQuakes } from '../functions/api/cluster-detail-with-quakes.js';
-import { onRequest as handlePostCalculateClusters } from '../functions/api/calculate-clusters.POST.js';
+import { onRequestPost as handlePostCalculateClusters } from '../functions/api/calculate-clusters.POST.js';
 
 // === Helper Functions (originally from [[catchall]].js) ===
 const jsonErrorResponse = (message, status, sourceName, upstreamStatus = undefined) => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,14 +16,10 @@ binding = "DB" # Binding name used in your Worker code
 database_name = "PrimaryDB" # Name of the D1 database (used in wrangler d1 commands)
 database_id = "8a0a26e9-ba3c-4984-9023-c1803f611a05" # Production D1 ID
 preview_database_id = "57ba069c-5763-41c3-965d-0df87b0ef26b" # Preview D1 ID for `wrangler dev`
-migrations = [
-  { tag = "0001", dir = "./migrations" },
-  { tag = "0002", dir = "./migrations" },
-  { tag = "0003", dir = "./migrations" },
-  { tag = "0004", dir = "./migrations" },
-  { tag = "0005", dir = "./migrations" },
-  { tag = "0008", dir = "./migrations" } # New trigger migration, 0006 is removed
-]
+# Migrations are typically handled by convention (./migrations directory)
+# or by a top-level `migrations_dir` setting, not within [[d1_databases]].
+# The previously existing `migrations = [...]` array within d1_databases was causing an error.
+# Wrangler should automatically detect the ./migrations directory for "PrimaryDB".
 
 [assets]
 directory = "./dist"


### PR DESCRIPTION
- Corrected import in `src/worker.js` to use `onRequestPost` as exported by `functions/api/calculate-clusters.POST.js`.
- Removed invalid `migrations` configuration from the `[[d1_databases]]` block in `wrangler.toml`. Wrangler will use convention to find migrations in the `./migrations` directory.

These changes address the primary build failure and the wrangler.toml parsing error related to migrations.