### PR TITLE
Fix: Update test suite for MSW and D1 changes

### DIFF
--- a/functions/api/calculate-clusters.logic.test.js
+++ b/functions/api/calculate-clusters.logic.test.js
@@ -1,4 +1,4 @@
-import { findActiveClusters } from './calculate-clusters';
+import { findActiveClusters } from './calculate-clusters.POST.js';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 // Helper to create mock quake for findActiveClusters tests

--- a/src/components/ClusterDetailModalWrapper.test.jsx
+++ b/src/components/ClusterDetailModalWrapper.test.jsx
@@ -225,7 +225,7 @@ describe('ClusterDetailModalWrapper', () => {
       );
 
       // Assertions based on the updated mock modal
-      await screen.findByText(`Location: ${mockReconstructedClusterForAssertion.locationName}`);
+      await screen.findByText(`Location: ${mockReconstructedClusterForAssertion.locationName}`, {}, { timeout: 3000 });
       expect(screen.getByText(`Cluster ID: ${oldFormatSlug}`)).toBeInTheDocument();
       expect(screen.getByText(`Magnitude: M ${mockReconstructedClusterForAssertion.maxMagnitude.toFixed(1)}`)).toBeInTheDocument();
       expect(screen.getByText(`Quake Count: ${mockReconstructedClusterForAssertion.quakeCount} Quakes`)).toBeInTheDocument();


### PR DESCRIPTION
- Corrected import paths in `calculate-clusters.endpoint.test.js` and `calculate-clusters.logic.test.js`.
- Refactored `functions/api/cluster-definition.test.js` to correctly mock `storeClusterDefinition` for POST requests and use the correct mock instance for D1 calls in GET requests.
- Updated `functions/api/calculate-clusters.POST.js` to use the imported `storeClusterDefinition` utility within `storeClusterDefinitionsInBackground`.
- Adjusted mock context in `calculate-clusters.endpoint.test.js` to correctly provide `waitUntil` under `ctx.waitUntil` and ensure promises are awaited in tests.
- Updated `src/components/EarthquakeDetailView.test.jsx` to use MSW handlers instead of a fetch spy.
- Added test-specific MSW handlers in `src/components/ClusterDetailModalWrapper.test.jsx` to ensure correct data for different scenarios and adjusted a test timeout to resolve remaining failures.