### PR TITLE
feat: Implement edge caching for API endpoints

### DIFF
--- a/functions/api/cluster-detail-with-quakes.js
+++ b/functions/api/cluster-detail-with-quakes.js
@@ -125,7 +125,10 @@ export async function onRequestGet(context) {
     // 3. Return Combined Data
     return new Response(JSON.stringify(clusterDefinition), {
       status: 200,
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, s-maxage=300', // Added Cache-Control header (5 minutes)
+      },
     });
 
   } catch (e) {

--- a/functions/api/get-earthquakes.js
+++ b/functions/api/get-earthquakes.js
@@ -114,6 +114,7 @@ export async function onRequestGet(context) {
       headers: {
         "Content-Type": "application/json",
         "X-Data-Source": "D1",
+        "Cache-Control": "public, s-maxage=60", // Added Cache-Control header
       },
     });
 
@@ -123,6 +124,7 @@ export async function onRequestGet(context) {
       status: 500,
       headers: {
         "X-Data-Source": "D1",
+        // No Cache-Control for error responses, or a short one like "public, s-maxage=5" if preferred
       },
     });
   }


### PR DESCRIPTION
Added Cache-Control headers to `get-earthquakes` and `cluster-detail-with-quakes` API endpoints to enable Cloudflare edge caching.

- `get-earthquakes` responses will be cached for 60 seconds.
- `cluster-detail-with-quakes` responses will be cached for 5 minutes.

This change aims to reduce D1 database load and improve API response times for end-users.