### PR TITLE
Fix: Update test suite to align with current logic

### DIFF
--- a/functions/routes/prerender/quake-detail.js
+++ b/functions/routes/prerender/quake-detail.js
@@ -69,6 +69,38 @@ export async function handleQuakeDetailPrerender(context, eventId) {
   <meta property="og:description" content="${escapeXml(description)}">
   <meta property="og:type" content="website">
   <meta property="og:url" content="${canonicalUrl}">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Event",
+      "name": "${title}",
+      "startDate": "${new Date(properties.time).toISOString()}",
+      "endDate": "${new Date(properties.time).toISOString()}",
+      "eventStatus": "https://schema.org/EventHappened",
+      "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+      "location": {
+        "@type": "Place",
+        "name": "${escapeXml(properties.place)}",
+        "geo": {
+          "@type": "GeoCoordinates",
+          "latitude": ${geometry.coordinates[1]},
+          "longitude": ${geometry.coordinates[0]},
+          "elevation": ${- (geometry.coordinates[2] || 0) * 1000}
+        }
+      },
+      "image": ["https://earthquakeslive.com/social-default-earthquake.png"],
+      "description": "${escapeXml(description)}",
+      "url": "${canonicalUrl}",
+      "organizer": {
+        "@type": "Organization",
+        "name": "Earthquakes Live",
+        "url": "https://earthquakeslive.com"
+      },
+      "identifier": "${eventId}",
+      "sameAs": "${escapeXml(PbfPropertiesUrl)}",
+      "keywords": "${escapeXml(properties.place.split(', ')[0].toLowerCase())}, ${escapeXml(properties.place.split(', ').slice(1).join(' ').toLowerCase())}, m${properties.mag.toFixed(1)}, earthquake, seismic event, earthquake report, ${new Date(properties.time).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }).toLowerCase().replace(',', '')}"
+    }
+  </script>
 </head>
 <body>
   <h1>${title}</h1>

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -107,6 +107,26 @@ export const handlers = [
       return new HttpResponse("Not Found", { status: 404 });
     }
 
+    // Handler for usgs_event_jsonld_test (from prerender-quake.integration.test.js)
+    if (eventId === 'usgs_event_jsonld_test') {
+      const eventTime = new Date(Date.UTC(2025, 5, 20, 17, 49, 14)).getTime();
+      return HttpResponse.json(
+        {
+          properties: {
+            mag: 5.1,
+            place: "36 km SW of Semnan, Iran",
+            time: eventTime,
+            detail: `https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&eventid=usgs_event_jsonld_test`,
+            title: `M 5.1 - 36 km SW of Semnan, Iran`,
+            url: `https://earthquake.usgs.gov/earthquakes/eventpage/usgs_event_jsonld_test`
+          },
+          geometry: { coordinates: [53.0699, 35.3758, 10] },
+          id: "usgs_event_jsonld_test"
+        },
+        { status: 200 }
+      );
+    }
+
     // Handlers for quake-detail.test.js
     const baseMockProperties = {
       mag: 5.8, place: '22 km ESE of Párga, Greece', time: 1672531200000, updated: 1672531500000, tz: null, // Adjusted time and place


### PR DESCRIPTION
- Corrected mock context setup for `executionContext.waitUntil` in various test files (primarily affecting `usgs-proxy` related tests).
- Updated MSW handlers to provide necessary mock data for specific test cases (e.g., `prerender-quake.integration.test.js`).
- Adjusted console spy expectations in tests to match updated log messages in application code.
- Fixed HTML generation in `quake-detail.js` to correctly include the JSON-LD script tag and ensure proper date formatting for keywords.
- Updated Vitest assertions to compatible matchers (e.g., `typeof value === 'string'` instead of `toBeString()`).
- Ensured `kvUtils.test.js` correctly passes `executionContext` to `setFeaturesToKV`.