### PR TITLE
Refactor: Remove unnecessary handleLoadMonthlyData dependency from us…

### DIFF
--- a/src/components/EarthquakeDetailView.jsx
+++ b/src/components/EarthquakeDetailView.jsx
@@ -145,7 +145,7 @@ function EarthquakeDetailView({ detailUrl, onClose, onDataLoadedForSeo, broaderE
             console.log('EarthquakeDetailView: Triggering monthly data load.');
             handleLoadMonthlyData();
         }
-    }, [detailUrl, hasAttemptedMonthlyLoad, isLoadingMonthly, handleLoadMonthlyData]); // Dependencies for the effect
+    }, [detailUrl, hasAttemptedMonthlyLoad, isLoadingMonthly]); // Dependencies for the effect - handleLoadMonthlyData REMOVED
 
     useEffect(() => {
         if (!detailUrl) {


### PR DESCRIPTION
…eEffect

Removes `handleLoadMonthlyData` from the dependency array of the `useEffect` hook in `EarthquakeDetailView.jsx`. This prevents potential unnecessary re-fetches of monthly data if the parent component's rendering behavior changes, as the function itself (even if memoized) was causing the effect to be re-evaluated.

The `handleLoadMonthlyData()` call remains within the effect, ensuring the logic to fetch monthly data under the correct conditions (changes in `detailUrl`, `hasAttemptedMonthlyLoad`, `isLoadingMonthly`) is preserved.