### PR TITLE
Refactor(ClusterDetailModalWrapper): Separate data fetching from URL …

### DIFF
--- a/src/components/ClusterDetailModalWrapper.jsx
+++ b/src/components/ClusterDetailModalWrapper.jsx
@@ -576,7 +576,7 @@ function ClusterDetailModalWrapper({
 
     }, [
         fetchStatus, // Primary driver
-        fullSlugFromParams, // For SEO and initial parsing trigger
+        // fullSlugFromParams, // For SEO and initial parsing trigger - REMOVED as per task
         effectiveQuakeId, // Core ID for fetching
         isOldFormat,      // Affects logic paths
         overviewClusters,


### PR DESCRIPTION
…parsing in useEffect

- Modified the main data fetching useEffect in ClusterDetailModalWrapper.jsx.
- Removed fullSlugFromParams from its dependency array to better separate URL parsing concerns (handled by a preceding effect) from data fetching logic.
- The data fetching effect now primarily depends on fetchStatus, effectiveQuakeId (clusterId), and other data-specific states and props.
- This change aligns with the goal of making the effect more focused on data operations, with URL parsing handled distinctly.