### PR TITLE
Fix: Correct import paths in sitemap and test files

### DIFF
--- a/functions/routes/sitemaps/index-sitemap.js
+++ b/functions/routes/sitemaps/index-sitemap.js
@@ -2,7 +2,7 @@
  * @file Generates the main sitemap index file (sitemap-index.xml).
  * This sitemap lists all individual sitemap files, including paginated earthquake sitemaps.
  */
-import { escapeXml } from '../utils/xml-utils.js'; // For error messages
+import { escapeXml } from '../../utils/xml-utils.js'; // For error messages
 
 // Constants adapted from earthquakes-sitemap.js
 const SITEMAP_PAGE_SIZE = 40000;

--- a/functions/sitemaps.earthquakes.test.js
+++ b/functions/sitemaps.earthquakes.test.js
@@ -1,7 +1,7 @@
 import { onRequest } from './[[catchall]]';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 
-import { MIN_FEELABLE_MAGNITUDE } from '../routes/sitemaps/earthquakes-sitemap.js'; // Reverted to standard relative path
+import { MIN_FEELABLE_MAGNITUDE } from './routes/sitemaps/earthquakes-sitemap.js'; // Reverted to standard relative path
 
 // --- Mocks for Cloudflare Environment ---
 const mockCache = {


### PR DESCRIPTION
Resolved test failures caused by incorrect relative import paths in:
- functions/routes/sitemaps/index-sitemap.js (for xml-utils.js)
- functions/sitemaps.earthquakes.test.js (for earthquakes-sitemap.js)

All test suites are now passing.