### PR TITLE
Fix: Update magnitude 7+ earthquake color for visibility

### DIFF
--- a/src/utils/getMagnitudeColor.test.js
+++ b/src/utils/getMagnitudeColor.test.js
@@ -36,12 +36,12 @@ describe('getMagnitudeColor', () => {
     expect(getMagnitudeColor(6.0)).toBe('#F87171'); // Changed from red-500
   });
 
-  it('should return slate-800 for magnitude 7.0', () => {
-    expect(getMagnitudeColor(7.0)).toBe('#1E293B'); // Changed from red-500
+  it('should return fuchsia-400 for magnitude 7.0', () => {
+    expect(getMagnitudeColor(7.0)).toBe('#E879F9');
   });
 
-  it('should return slate-800 for magnitude 8.0', () => {
-    expect(getMagnitudeColor(8.0)).toBe('#1E293B'); // Changed from red-700
+  it('should return fuchsia-400 for magnitude 8.0', () => {
+    expect(getMagnitudeColor(8.0)).toBe('#E879F9');
   });
 
   // Test with magnitudes within each color category
@@ -69,13 +69,13 @@ describe('getMagnitudeColor', () => {
     expect(getMagnitudeColor(6.5)).toBe('#F87171'); // Changed from red-500
   });
 
-  it('should return slate-800 for magnitude 7.5', () => {
-    expect(getMagnitudeColor(7.5)).toBe('#1E293B'); // Changed from red-500
+  it('should return fuchsia-400 for magnitude 7.5', () => {
+    expect(getMagnitudeColor(7.5)).toBe('#E879F9');
   });
 
   // Test with a very high magnitude (>= 8.0)
-  it('should return slate-800 for magnitude 9.0 (very high)', () => {
-    expect(getMagnitudeColor(9.0)).toBe('#1E293B'); // Changed from red-700
+  it('should return fuchsia-400 for magnitude 9.0 (very high)', () => {
+    expect(getMagnitudeColor(9.0)).toBe('#E879F9');
   });
 
   // Test with negative magnitudes

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -20,7 +20,7 @@ export const getMagnitudeColor = (magnitude) => {
     if (magnitude < 5.0) return '#FACC15'; // yellow-400
     if (magnitude < 6.0) return '#FB923C'; // orange-400
     if (magnitude < 7.0) return '#F87171'; // red-400 (Magnitude 6.x)
-    return '#1E293B'; // slate-800 (Magnitude 7.0+)
+    return '#E879F9'; // fuchsia-400 (Magnitude 7.0+)
 };
 
 /**
@@ -37,7 +37,7 @@ export const getMagnitudeColorStyle = (magnitude) => {
     if (magnitude < 5.0) return 'bg-yellow-400 text-slate-900';     // text-slate-900 for contrast
     if (magnitude < 6.0) return 'bg-orange-400 text-slate-900';     // text-slate-900 for contrast
     if (magnitude < 7.0) return 'bg-red-400 text-slate-900';       // Magnitude 6.x, text-slate-900 for contrast
-    return 'bg-slate-800 text-white';                             // Magnitude 7.0+, text-white for contrast
+    return 'bg-fuchsia-400 text-white';                           // Magnitude 7.0+, text-white for contrast
 };
 
 // Add other utility functions here as the app grows


### PR DESCRIPTION
The previous color for magnitude 7.0 and greater earthquakes was slate-800, which was not visible on dark backgrounds. This change updates the color to fuchsia-400, a bright and contrasting color, to ensure it is clearly visible.

I have also updated the corresponding tests to reflect this change.